### PR TITLE
Add base for generation of function calls

### DIFF
--- a/tools/fuzzer/ast.cc
+++ b/tools/fuzzer/ast.cc
@@ -424,6 +424,23 @@ std::ostream& operator<<(std::ostream& os, const DereferenceExpr& expr) {
   return os << "*" << expr.expr();
 }
 
+FunctionCallExpr::FunctionCallExpr(std::string name,
+                                   std::vector<std::shared_ptr<Expr>> args)
+    : name_(std::move(name)), args_(std::move(args)) {}
+const std::string& FunctionCallExpr::name() const { return name_; }
+const std::vector<std::shared_ptr<Expr>>& FunctionCallExpr::args() const {
+  return args_;
+}
+std::ostream& operator<<(std::ostream& os, const FunctionCallExpr& expr) {
+  os << expr.name() << "(";
+  const auto& args = expr.args();
+  for (size_t i = 0; i < args.size(); ++i) {
+    if (i > 0) os << ", ";
+    os << *args[i];
+  }
+  return os << ")";
+}
+
 std::ostream& operator<<(std::ostream& os, const BooleanConstant& expr) {
   const char* to_print = expr.value() ? "true" : "false";
   return os << to_print;
@@ -568,6 +585,21 @@ class ExprDumper {
     emit_marked_indentation();
     printf("Dereference:\n");
     indented_visit(e.expr());
+  }
+
+  void operator()(const FunctionCallExpr& e) {
+    emit_marked_indentation();
+    printf("Function call:\n");
+
+    emit_indentation();
+    printf("Name: `%s`\n", e.name().c_str());
+
+    const auto& args = e.args();
+    for (size_t i = 0; i < args.size(); ++i) {
+      emit_indentation();
+      printf("Argument #%zu:", i + 1);
+      indented_visit(*args[i]);
+    }
   }
 
   void operator()(const BooleanConstant& e) {

--- a/tools/fuzzer/ast.cc
+++ b/tools/fuzzer/ast.cc
@@ -435,7 +435,9 @@ std::ostream& operator<<(std::ostream& os, const FunctionCallExpr& expr) {
   os << expr.name() << "(";
   const auto& args = expr.args();
   for (size_t i = 0; i < args.size(); ++i) {
-    if (i > 0) os << ", ";
+    if (i > 0) {
+      os << ", ";
+    }
     os << *args[i];
   }
   return os << ")";

--- a/tools/fuzzer/ast.h
+++ b/tools/fuzzer/ast.h
@@ -24,6 +24,7 @@
 #include <string>
 #include <typeindex>  // forward references `std::hash`
 #include <variant>
+#include <vector>
 
 #include "tools/fuzzer/enum_bitset.h"
 
@@ -169,6 +170,7 @@ class ArrayIndex;
 class TernaryExpr;
 class CastExpr;
 class DereferenceExpr;
+class FunctionCallExpr;
 class BooleanConstant;
 class NullptrConstant;
 class EnumConstant;
@@ -216,11 +218,11 @@ enum class BinOp : unsigned char {
 inline constexpr size_t NUM_BIN_OPS = (size_t)BinOp::EnumLast + 1;
 int bin_op_precedence(BinOp op);
 
-using Expr =
-    std::variant<IntegerConstant, DoubleConstant, VariableExpr, UnaryExpr,
-                 BinaryExpr, AddressOf, MemberOf, MemberOfPtr, ArrayIndex,
-                 TernaryExpr, CastExpr, DereferenceExpr, BooleanConstant,
-                 NullptrConstant, EnumConstant, ParenthesizedExpr>;
+using Expr = std::variant<IntegerConstant, DoubleConstant, VariableExpr,
+                          UnaryExpr, BinaryExpr, AddressOf, MemberOf,
+                          MemberOfPtr, ArrayIndex, TernaryExpr, CastExpr,
+                          DereferenceExpr, FunctionCallExpr, BooleanConstant,
+                          NullptrConstant, EnumConstant, ParenthesizedExpr>;
 inline constexpr size_t NUM_EXPR_KINDS = std::variant_size_v<Expr>;
 void dump_expr(const Expr& expr);
 std::ostream& operator<<(std::ostream& os, const Expr& expr);
@@ -533,6 +535,25 @@ class DereferenceExpr {
 
  private:
   std::shared_ptr<Expr> expr_;
+};
+
+class FunctionCallExpr {
+ public:
+  static constexpr int PRECEDENCE = 2;
+
+  FunctionCallExpr() = default;
+  FunctionCallExpr(std::string name, std::vector<std::shared_ptr<Expr>> args);
+
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const FunctionCallExpr& expr);
+
+  const std::string& name() const;
+  const std::vector<std::shared_ptr<Expr>>& args() const;
+  int precedence() const { return PRECEDENCE; }
+
+ private:
+  std::string name_;
+  std::vector<std::shared_ptr<Expr>> args_;
 };
 
 class BooleanConstant {

--- a/tools/fuzzer/constraints.cc
+++ b/tools/fuzzer/constraints.cc
@@ -90,7 +90,7 @@ SpecificTypes SpecificTypes::make_pointer_constraints(
   return retval;
 }
 
-SpecificTypes SpecificTypes::cast_to(Type type) {
+SpecificTypes SpecificTypes::cast_to(const Type& type) {
   if (std::holds_alternative<TaggedType>(type)) {
     return SpecificTypes();
   }
@@ -131,7 +131,7 @@ SpecificTypes SpecificTypes::cast_to(Type type) {
   return SpecificTypes();
 }
 
-SpecificTypes SpecificTypes::static_cast_to(Type type) {
+SpecificTypes SpecificTypes::static_cast_to(const Type& type) {
   if (std::holds_alternative<TaggedType>(type)) {
     return SpecificTypes();
   }
@@ -162,7 +162,7 @@ SpecificTypes SpecificTypes::static_cast_to(Type type) {
   return SpecificTypes();
 }
 
-SpecificTypes SpecificTypes::reinterpret_cast_to(Type type) {
+SpecificTypes SpecificTypes::reinterpret_cast_to(const Type& type) {
   if (std::holds_alternative<TaggedType>(type) ||
       std::holds_alternative<NullptrType>(type) ||
       std::holds_alternative<ScalarType>(type)) {
@@ -177,6 +177,29 @@ SpecificTypes SpecificTypes::reinterpret_cast_to(Type type) {
 
   if (std::holds_alternative<EnumType>(type)) {
     return SpecificTypes(type);
+  }
+
+  assert(false && "Did you introduce a new alternative?");
+  return SpecificTypes();
+}
+
+SpecificTypes SpecificTypes::implicit_cast_to(const Type& type) {
+  if (std::holds_alternative<TaggedType>(type) ||
+      std::holds_alternative<PointerType>(type) ||
+      std::holds_alternative<NullptrType>(type) ||
+      std::holds_alternative<EnumType>(type)) {
+    return SpecificTypes(type);
+  }
+
+  const auto* scalar_type = std::get_if<ScalarType>(&type);
+  if (scalar_type != nullptr) {
+    if (*scalar_type == ScalarType::Void) {
+      return SpecificTypes(type);
+    }
+
+    SpecificTypes retval = INT_TYPES | FLOAT_TYPES;
+    retval.allow_unscoped_enums();
+    return retval;
   }
 
   assert(false && "Did you introduce a new alternative?");

--- a/tools/fuzzer/constraints.h
+++ b/tools/fuzzer/constraints.h
@@ -105,13 +105,17 @@ class SpecificTypes {
       VoidPointerConstraint void_ptr_constraint = VoidPointerConstraint::Deny);
 
   // Types that can be cast to the `type`, using a C-style cast.
-  static SpecificTypes cast_to(Type type);
+  static SpecificTypes cast_to(const Type& type);
 
   // Types that can be cast to the `type`, using a `static_cast`.
-  static SpecificTypes static_cast_to(Type type);
+  static SpecificTypes static_cast_to(const Type& type);
 
   // Types that can be cast to the `type`, using a `reinterpret_cast`.
-  static SpecificTypes reinterpret_cast_to(Type type);
+  static SpecificTypes reinterpret_cast_to(const Type& type);
+
+  // Types that can be implicitly cast to the `type`, e.g. when passing
+  // arguments to function calls.
+  static SpecificTypes implicit_cast_to(const Type& type);
 
   // Is there any type that satisfies these constraints?
   bool satisfiable() const {

--- a/tools/fuzzer/expr_gen.cc
+++ b/tools/fuzzer/expr_gen.cc
@@ -1236,7 +1236,7 @@ EnumConstant DefaultGeneratorRng::pick_enum_literal(
   return pick_element(enums, rng_);
 }
 
-const Function& DefaultGeneratorRng::pick_function(
+Function DefaultGeneratorRng::pick_function(
     const std::vector<std::reference_wrapper<const Function>>& functions) {
   return pick_element(functions, rng_);
 }

--- a/tools/fuzzer/expr_gen.h
+++ b/tools/fuzzer/expr_gen.h
@@ -45,6 +45,7 @@ enum class ExprKind : unsigned char {
   NullptrConstant,
   EnumConstant,
   DereferenceExpr,
+  FunctionCallExpr,
   CastExpr,
   EnumLast = CastExpr,
 };
@@ -154,6 +155,7 @@ struct GenConfig {
       {1.0f, 0.0f},  // ExprKind::NullptrConstant
       {1.0f, 0.0f},  // ExprKind::EnumConstant
       {1.0f, 0.1f},  // ExprKind::DereferenceExpr
+      {1.0f, 0.1f},  // ExprKind::FunctionCallExpr
       {1.0f, 0.4f},  // ExprKind::CastExpr
   }};
 
@@ -201,6 +203,8 @@ class GeneratorRng {
       const std::vector<std::reference_wrapper<const EnumType>>& types) = 0;
   virtual EnumConstant pick_enum_literal(
       const std::vector<std::reference_wrapper<const EnumConstant>>& enums) = 0;
+  virtual const Function& pick_function(
+      const std::vector<std::reference_wrapper<const Function>>& functions) = 0;
 };
 
 class DefaultGeneratorRng : public GeneratorRng {
@@ -238,6 +242,9 @@ class DefaultGeneratorRng : public GeneratorRng {
       override;
   EnumConstant pick_enum_literal(
       const std::vector<std::reference_wrapper<const EnumConstant>>& enums)
+      override;
+  const Function& pick_function(
+      const std::vector<std::reference_wrapper<const Function>>& functions)
       override;
 
  private:
@@ -281,6 +288,8 @@ class ExprGenerator {
       const Weights& weights, const ExprConstraints& constraints);
   std::optional<Expr> gen_array_index_expr(const Weights& weights,
                                            const ExprConstraints& constraints);
+  std::optional<Expr> gen_function_call_expr(
+      const Weights& weights, const ExprConstraints& constraints);
 
   std::optional<Type> gen_type(const Weights& weights,
                                const TypeConstraints& constraints);

--- a/tools/fuzzer/expr_gen.h
+++ b/tools/fuzzer/expr_gen.h
@@ -203,7 +203,7 @@ class GeneratorRng {
       const std::vector<std::reference_wrapper<const EnumType>>& types) = 0;
   virtual EnumConstant pick_enum_literal(
       const std::vector<std::reference_wrapper<const EnumConstant>>& enums) = 0;
-  virtual const Function& pick_function(
+  virtual Function pick_function(
       const std::vector<std::reference_wrapper<const Function>>& functions) = 0;
 };
 
@@ -243,7 +243,7 @@ class DefaultGeneratorRng : public GeneratorRng {
   EnumConstant pick_enum_literal(
       const std::vector<std::reference_wrapper<const EnumConstant>>& enums)
       override;
-  const Function& pick_function(
+  Function pick_function(
       const std::vector<std::reference_wrapper<const Function>>& functions)
       override;
 

--- a/tools/fuzzer/fuzzer_test.cc
+++ b/tools/fuzzer/fuzzer_test.cc
@@ -156,7 +156,7 @@ class FakeGeneratorRng : public GeneratorRng {
     return fuzzer::Field(std::move(type), std::move(field_name));
   }
 
-  const fuzzer::Function& pick_function(
+  fuzzer::Function pick_function(
       const std::vector<std::reference_wrapper<const fuzzer::Function>>&)
       override {
     assert(false && "Not implemented yet!");
@@ -369,7 +369,7 @@ class FakeGeneratorRng : public GeneratorRng {
     std::visit(*this, e.expr());
   }
 
-  void operator()(const FunctionCallExpr& e) {
+  void operator()(const FunctionCallExpr&) {
     assert(false && "Not implemented yet!");
   }
 

--- a/tools/fuzzer/symbol_table.h
+++ b/tools/fuzzer/symbol_table.h
@@ -53,6 +53,19 @@ class Field {
   std::string name_;
 };
 
+class Function {
+ public:
+  Function(std::string name, std::vector<Type> argument_types)
+      : name_(std::move(name)), argument_types_(std::move(argument_types)) {}
+
+  const std::string& name() const { return name_; }
+  const std::vector<Type>& argument_types() const { return argument_types_; }
+
+ private:
+  std::string name_;
+  std::vector<Type> argument_types_;
+};
+
 class SymbolTable {
  public:
   SymbolTable() = default;
@@ -81,8 +94,18 @@ class SymbolTable {
     enum_map_[enum_type].emplace_back(enum_type, std::move(enum_literal));
   }
 
+  void add_function(Type return_type, std::string name,
+                    std::vector<Type> argument_types) {
+    function_map_[std::move(return_type)].emplace_back(
+        std::move(name), std::move(argument_types));
+  }
+
   const std::unordered_map<Type, std::vector<Field>>& fields_by_type() const {
     return fields_by_type_;
+  }
+
+  const std::unordered_map<Type, std::vector<Function>>& functions() const {
+    return function_map_;
   }
 
   const std::unordered_map<EnumType, std::vector<EnumConstant>>& enums() const {
@@ -95,6 +118,7 @@ class SymbolTable {
 
  private:
   std::unordered_map<Type, std::vector<VariableFreedomPair>> var_map_;
+  std::unordered_map<Type, std::vector<Function>> function_map_;
   std::unordered_map<Type, std::vector<Field>> fields_by_type_;
   std::unordered_map<EnumType, std::vector<EnumConstant>> enum_map_;
   std::unordered_set<TaggedType> tagged_types_;


### PR DESCRIPTION
This change implements `FunctionCallExpr` node. It is tested with `__log2`, currently the only function supported by lldb-eval. Unfortunately, `__log2` isn't supported by LLDB, so this expression kind won't be used until there's a function supported by both LLDB and lldb-eval.