### PR TITLE
Populate structs and global variables in symbol table

### DIFF
--- a/testdata/fuzzer_binary.cc
+++ b/testdata/fuzzer_binary.cc
@@ -142,6 +142,8 @@ enum class EnumClass { ZERO, ONE, TWO, THREE };
 
 // Global variables
 int global_int = 55;
+int* global_ptr = &global_int;
+int& global_ref = global_int;
 TestStruct global_ts;
 
 namespace ns {
@@ -157,6 +159,8 @@ enum class EnumClass { ZERO, ONE, TWO, THREE };
 
 // Global variables:
 int global_int = 65;
+int* global_ptr = &global_int;
+int& global_ref = global_int;
 TestStruct global_ts;
 
 namespace nested_ns {

--- a/tools/fuzzer/main.cc
+++ b/tools/fuzzer/main.cc
@@ -173,24 +173,6 @@ fuzzer::SymbolTable gen_symtab(lldb::SBFrame& frame,
       };
 
   {
-    fuzzer::TaggedType type("TestStruct");
-    fuzzer::TaggedType ns_type("ns::nested_ns::TestStruct");
-
-    add_field("int_field", fuzzer::ScalarType::SignedInt, {type, ns_type});
-    add_field("flt_field", fuzzer::ScalarType::Float, {type, ns_type});
-    add_field("ch_field", fuzzer::ScalarType::Char, {type, ns_type});
-    symtab.add_field(type, "ull_field", fuzzer::ScalarType::UnsignedLongLong);
-
-    symtab.add_var(type, fuzzer::VariableExpr("ts"));
-    symtab.add_var(ns_type, fuzzer::VariableExpr("ns_ts"));
-
-    // Also add global variables.
-    symtab.add_var(type, fuzzer::VariableExpr("global_ts"));
-    symtab.add_var(type, fuzzer::VariableExpr("ns::global_ts"));
-    symtab.add_var(ns_type, fuzzer::VariableExpr("ns::nested_ns::global_ts"));
-  }
-
-  {
     fuzzer::TaggedType base1("MultiInheritBase1");
     fuzzer::TaggedType base2("MultiInheritBase2");
     fuzzer::TaggedType derived("MultiInheritDerived");
@@ -249,43 +231,6 @@ fuzzer::SymbolTable gen_symtab(lldb::SBFrame& frame,
     symtab.add_var(with_nested, fuzzer::VariableExpr("with_nested"));
     symtab.add_field(with_nested, "nested", nested);
     symtab.add_field(nested, "f1", fuzzer::ScalarType::SignedInt);
-  }
-
-  {
-    fuzzer::TaggedType type("LocalStruct");
-    fuzzer::PointerType ptr_int_type{
-        fuzzer::QualifiedType(fuzzer::ScalarType::SignedInt)};
-
-    symtab.add_var(type, fuzzer::VariableExpr("ls"));
-    symtab.add_field(type, "int_field", fuzzer::ScalarType::SignedInt);
-    symtab.add_field(type, "ref_field", fuzzer::ScalarType::SignedInt);
-    symtab.add_field(type, "ptr_field", ptr_int_type);
-    symtab.add_field(type, "ptr_ref_field", ptr_int_type);
-    symtab.add_field(type, "dbl_field", fuzzer::ScalarType::Double);
-  }
-
-  {
-    // Add static members.
-    if (cv_qualifiers_enabled) {
-      symtab.add_var(fuzzer::ScalarType::SignedInt,
-                     fuzzer::VariableExpr("StaticMember::s1"));
-      symtab.add_var(fuzzer::ScalarType::SignedInt,
-                     fuzzer::VariableExpr("ns::StaticMember::s1"));
-      symtab.add_var(
-          fuzzer::ScalarType::SignedInt,
-          fuzzer::VariableExpr("ClassWithNestedClass::NestedClass::s1"));
-    }
-
-    symtab.add_var(fuzzer::ScalarType::Char,
-                   fuzzer::VariableExpr("StaticMember::s2"));
-
-    // Add global variables.
-    symtab.add_var(fuzzer::ScalarType::SignedInt,
-                   fuzzer::VariableExpr("global_int"));
-    symtab.add_var(fuzzer::ScalarType::SignedInt,
-                   fuzzer::VariableExpr("ns::global_int"));
-    symtab.add_var(fuzzer::ScalarType::SignedInt,
-                   fuzzer::VariableExpr("ns::nested_ns::global_int"));
   }
 
   {

--- a/tools/fuzzer/symbol_table.cc
+++ b/tools/fuzzer/symbol_table.cc
@@ -175,12 +175,18 @@ int calculate_freedom_index(lldb::SBValue value,
 }
 
 // Fix variable/field names returned by LLDB API. E.g. name is sometimes in
-// the form of "type name", so it ignores everything in front of the last
-// occurrence of ' ' (space).
+// the form of "type name" or "type *name", so it ignores everything in front of
+// the last occurrence of ' ' (space), '*' or '&'.
 const char* fix_name(const char* name) {
-  const char* last_space = strrchr(name, ' ');
-  if (last_space != nullptr) {
-    return last_space + 1;
+  // Find the last occurrence of ' ', '*' or '&' in the `name`.
+  const char* last_occurrence = nullptr;
+  for (const char* c = name; *c != '\0'; ++c) {
+    if (*c == ' ' || *c == '*' || *c == '&') {
+      last_occurrence = c;
+    }
+  }
+  if (last_occurrence != nullptr) {
+    return last_occurrence + 1;
   }
   return name;
 }

--- a/tools/fuzzer/symbol_table.cc
+++ b/tools/fuzzer/symbol_table.cc
@@ -17,7 +17,6 @@
 #include "tools/fuzzer/symbol_table.h"
 
 #include <cstring>
-#include <iostream>
 #include <optional>
 #include <string>
 
@@ -83,8 +82,7 @@ std::optional<Type> convert_type(lldb::SBType type,
                                      guess_cv_qualifiers(pointee_type)));
   }
 
-  if (type.GetTypeClass() == lldb::eTypeClassClass ||
-      type.GetTypeClass() == lldb::eTypeClassStruct) {
+  if (type.GetTypeClass() == lldb::eTypeClassStruct) {
     return TaggedType(type.GetName());
   }
 
@@ -217,9 +215,8 @@ SymbolTable SymbolTable::create_from_lldb_context(lldb::SBFrame& frame,
     }
   }
 
-  // Populate class and struct fields.
-  lldb::SBTypeList types = frame.GetModule().GetTypes(lldb::eTypeClassClass |
-                                                      lldb::eTypeClassStruct);
+  // Populate struct fields.
+  lldb::SBTypeList types = frame.GetModule().GetTypes(lldb::eTypeClassStruct);
   uint32_t types_size = types.GetSize();
 
   for (uint32_t i = 0; i < types_size; ++i) {

--- a/tools/fuzzer/symbol_table_test.cc
+++ b/tools/fuzzer/symbol_table_test.cc
@@ -16,6 +16,8 @@
 
 #include "tools/fuzzer/symbol_table.h"
 
+#include <algorithm>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "lldb-eval/runner.h"
@@ -25,32 +27,52 @@
 #include "lldb/API/SBThread.h"
 #include "tools/cpp/runfiles/runfiles.h"
 
+using namespace fuzzer;
 using namespace testing;
 using bazel::tools::cpp::runfiles::Runfiles;
 
-TEST(SymbolTableTest, CreateFromLldbContext) {
-  // Set up the test.
-  std::unique_ptr<Runfiles> runfiles(Runfiles::CreateForTest());
-  lldb_eval::SetupLLDBServerEnv(*runfiles);
-  lldb::SBDebugger::Initialize();
-  auto binary_path = runfiles->Rlocation("lldb_eval/testdata/fuzzer_binary");
-  auto source_path = runfiles->Rlocation("lldb_eval/testdata/fuzzer_binary.cc");
-  auto debugger = lldb::SBDebugger::Create(false);
-  auto process = lldb_eval::LaunchTestProgram(debugger, source_path,
-                                              binary_path, "// BREAK HERE");
-  auto frame = process.GetSelectedThread().GetSelectedFrame();
+class PopulateSymbolTableTest : public Test {
+ protected:
+  static void SetUpTestSuite() {
+    runfiles_ = Runfiles::CreateForTest();
+    lldb_eval::SetupLLDBServerEnv(*runfiles_);
+    lldb::SBDebugger::Initialize();
+    auto binary_path = runfiles_->Rlocation("lldb_eval/testdata/fuzzer_binary");
+    auto source_path =
+        runfiles_->Rlocation("lldb_eval/testdata/fuzzer_binary.cc");
+    auto debugger = lldb::SBDebugger::Create(false);
+    process_ = lldb_eval::LaunchTestProgram(debugger, source_path, binary_path,
+                                            "// BREAK HERE");
+    auto frame = process_.GetSelectedThread().GetSelectedFrame();
+    symtab_ = SymbolTable::create_from_lldb_context(frame);
+  }
 
-  // Create a symbol table from LLDB context.
-  fuzzer::SymbolTable symtab =
-      fuzzer::SymbolTable::create_from_lldb_context(frame);
+  static void TearDownTestSuite() {
+    process_.Destroy();
+    lldb::SBDebugger::Terminate();
+    delete runfiles_;
+    runfiles_ = nullptr;
+  }
 
+ protected:
+  lldb::SBFrame frame_;
+
+  static Runfiles* runfiles_;
+  static lldb::SBProcess process_;
+  static SymbolTable symtab_;
+};
+
+Runfiles* PopulateSymbolTableTest::runfiles_ = nullptr;
+lldb::SBProcess PopulateSymbolTableTest::process_;
+SymbolTable PopulateSymbolTableTest::symtab_;
+
+TEST_F(PopulateSymbolTableTest, Variables) {
   size_t count_checked_types = 0;
 
-  auto expect_vars = [&symtab, &count_checked_types](
-                         fuzzer::Type type,
-                         const std::set<std::string>& names) {
-    auto var_it = symtab.vars().find(type);
-    ASSERT_NE(var_it, symtab.vars().end());
+  auto expect_vars = [this, &count_checked_types](
+                         Type type, const std::set<std::string>& names) {
+    auto var_it = symtab_.vars().find(type);
+    ASSERT_NE(var_it, symtab_.vars().end());
     std::set<std::string> names_from_symtab;
     for (const auto& var : var_it->second) {
       names_from_symtab.insert(var.expr.name());
@@ -60,47 +82,49 @@ TEST(SymbolTableTest, CreateFromLldbContext) {
   };
 
   // Check contents of the symbol table.
-  expect_vars(fuzzer::ScalarType::Char, {"char_min", "char_max"});
-  expect_vars(fuzzer::ScalarType::SignedChar, {"schar_min", "schar_max"});
-  expect_vars(fuzzer::ScalarType::UnsignedChar, {"uchar_min", "uchar_max"});
-  expect_vars(fuzzer::ScalarType::UnsignedShort, {"ushort_min", "ushort_max"});
-  expect_vars(fuzzer::ScalarType::SignedShort, {"short_min", "short_max"});
-  expect_vars(fuzzer::ScalarType::UnsignedInt, {"uint_min", "uint_max"});
+  expect_vars(ScalarType::Char, {"char_min", "char_max", "StaticMember::s2"});
+  expect_vars(ScalarType::SignedChar, {"schar_min", "schar_max"});
+  expect_vars(ScalarType::UnsignedChar, {"uchar_min", "uchar_max"});
+  expect_vars(ScalarType::UnsignedShort, {"ushort_min", "ushort_max"});
+  expect_vars(ScalarType::SignedShort, {"short_min", "short_max"});
+  expect_vars(ScalarType::UnsignedInt, {"uint_min", "uint_max"});
   expect_vars(
-      fuzzer::ScalarType::SignedInt,
-      {"int_min", "int_max", "x", "ref" /* references aren't supported yet */});
-  expect_vars(fuzzer::ScalarType::UnsignedLong, {"ulong_min", "ulong_max"});
-  expect_vars(fuzzer::ScalarType::SignedLong, {"long_min", "long_max"});
-  expect_vars(fuzzer::ScalarType::UnsignedLongLong,
-              {"ullong_min", "ullong_max"});
-  expect_vars(fuzzer::ScalarType::SignedLongLong, {"llong_min", "llong_max"});
-  expect_vars(fuzzer::ScalarType::Float,
-              {"fnan", "finf", "fsnan", "fmax", "fdenorm"});
-  expect_vars(fuzzer::ScalarType::Double,
-              {"dnan", "dinf", "dsnan", "dmax", "ddenorm"});
-  expect_vars(fuzzer::ScalarType::LongDouble,
+      ScalarType::SignedInt,
+      {"int_min", "int_max", "x", "ref" /* references aren't supported yet */,
+       "global_int", "ns::global_int", "ns::nested_ns::global_int",
+       "StaticMember::s1", "ns::StaticMember::s1",
+       "ClassWithNestedClass::NestedClass::s1"});
+  expect_vars(ScalarType::UnsignedLong, {"ulong_min", "ulong_max"});
+  expect_vars(ScalarType::SignedLong, {"long_min", "long_max"});
+  expect_vars(ScalarType::UnsignedLongLong, {"ullong_min", "ullong_max"});
+  expect_vars(ScalarType::SignedLongLong, {"llong_min", "llong_max"});
+  expect_vars(ScalarType::Float, {"fnan", "finf", "fsnan", "fmax", "fdenorm"});
+  expect_vars(ScalarType::Double, {"dnan", "dinf", "dsnan", "dmax", "ddenorm"});
+  expect_vars(ScalarType::LongDouble,
               {"ldnan", "ldinf", "ldsnan", "ldmax", "lddenorm"});
-  fuzzer::Type int_ptr =
-      fuzzer::PointerType(fuzzer::QualifiedType(fuzzer::ScalarType::SignedInt));
+  Type int_ptr = PointerType(QualifiedType(ScalarType::SignedInt));
   expect_vars(int_ptr, {"p"});
-  expect_vars(fuzzer::PointerType(fuzzer::QualifiedType(int_ptr)),
-              {"q", "refp"});
-  expect_vars(
-      fuzzer::PointerType(fuzzer::QualifiedType(fuzzer::ScalarType::Void)),
-      {"void_ptr"});
-  fuzzer::Type char_ptr =
-      fuzzer::PointerType(fuzzer::QualifiedType(fuzzer::ScalarType::Char));
-  expect_vars(char_ptr, {"test_str", "null_char_ptr"});
-  expect_vars(fuzzer::PointerType(fuzzer::QualifiedType(char_ptr)),
-              {"addr_null_char_ptr"});
-  expect_vars(fuzzer::NullptrType{}, {"null_ptr", "ref_null_ptr"});
-  expect_vars(fuzzer::PointerType(fuzzer::QualifiedType(fuzzer::NullptrType{})),
-              {"addr_null_ptr"});
+  expect_vars(PointerType(QualifiedType(int_ptr)), {"q"});
+  expect_vars(PointerType(QualifiedType(int_ptr, CvQualifier::Const)),
+              {"refp"});
+  expect_vars(PointerType(QualifiedType(ScalarType::Void)), {"void_ptr"});
+  Type char_ptr = PointerType(QualifiedType(ScalarType::Char));
+  expect_vars(char_ptr, {"null_char_ptr"});
+  expect_vars(PointerType(QualifiedType(ScalarType::Char, CvQualifier::Const)),
+              {"test_str"});
+  expect_vars(PointerType(QualifiedType(char_ptr)), {"addr_null_char_ptr"});
+  expect_vars(NullptrType{}, {"null_ptr", "ref_null_ptr"});
+  expect_vars(PointerType(QualifiedType(NullptrType{})), {"addr_null_ptr"});
+  expect_vars(TaggedType("TestStruct"), {"ts", "global_ts", "ns::global_ts"});
+  expect_vars(TaggedType("LocalStruct"), {"ls"});
+  expect_vars(TaggedType("ns::nested_ns::TestStruct"),
+              {"ns_ts", "ns::nested_ns::global_ts"});
 
   // Make sure there isn't a type we forgot to check.
-  EXPECT_EQ(count_checked_types, symtab.vars().size());
+  EXPECT_EQ(count_checked_types, symtab_.vars().size());
+}
 
-  // Compare freedom indices.
+TEST_F(PopulateSymbolTableTest, FreedomIndices) {
   std::unordered_map<std::string, int> freedom_indices;
   freedom_indices["p"] = 1;
   freedom_indices["q"] = 2;
@@ -111,7 +135,7 @@ TEST(SymbolTableTest, CreateFromLldbContext) {
   freedom_indices["addr_null_char_ptr"] = 1;
 
   size_t variable_count = 0;
-  for (const auto& [type, vars] : symtab.vars()) {
+  for (const auto& [type, vars] : symtab_.vars()) {
     for (const auto& var : vars) {
       variable_count++;
       EXPECT_EQ(var.freedom_index, freedom_indices[var.expr.name()]);
@@ -120,8 +144,49 @@ TEST(SymbolTableTest, CreateFromLldbContext) {
 
   // Make sure we checked freedom indices of all variables.
   EXPECT_EQ(variable_count, freedom_indices.size());
+}
 
-  // Teardown the test.
-  process.Destroy();
-  lldb::SBDebugger::Terminate();
+namespace fuzzer {
+bool operator==(const Field& lhs, const Field& rhs) {
+  return lhs.containing_type() == rhs.containing_type() &&
+         lhs.name() == rhs.name();
+}
+}  // namespace fuzzer
+
+TEST_F(PopulateSymbolTableTest, TaggedTypesAndFields) {
+  auto expect_field = [this](const TaggedType& containing_type,
+                             std::string field_name, const Type& field_type) {
+    const fuzzer::Field field(containing_type, std::move(field_name));
+    const auto fields_it = symtab_.fields_by_type().find(field_type);
+    ASSERT_NE(fields_it, symtab_.fields_by_type().end());
+    EXPECT_THAT(fields_it->second, Contains(field));
+  };
+
+  {
+    const TaggedType tagged_type("TestStruct");
+    EXPECT_THAT(symtab_.tagged_types(), Contains(tagged_type));
+    expect_field(tagged_type, "int_field", ScalarType::SignedInt);
+    expect_field(tagged_type, "ch_field", ScalarType::Char);
+    expect_field(tagged_type, "flt_field", ScalarType::Float);
+    expect_field(tagged_type, "ull_field", ScalarType::UnsignedLongLong);
+  }
+
+  {
+    const TaggedType tagged_type("ns::nested_ns::TestStruct");
+    EXPECT_THAT(symtab_.tagged_types(), Contains(tagged_type));
+    expect_field(tagged_type, "int_field", ScalarType::SignedInt);
+    expect_field(tagged_type, "ch_field", ScalarType::Char);
+    expect_field(tagged_type, "flt_field", ScalarType::Float);
+  }
+
+  {
+    const TaggedType tagged_type("LocalStruct");
+    EXPECT_THAT(symtab_.tagged_types(), Contains(tagged_type));
+    expect_field(tagged_type, "int_field", ScalarType::SignedInt);
+    expect_field(tagged_type, "ref_field", ScalarType::SignedInt);
+    expect_field(tagged_type, "dbl_field", ScalarType::Double);
+    const Type ptr_type = PointerType(QualifiedType(ScalarType::SignedInt));
+    expect_field(tagged_type, "ptr_field", ptr_type);
+    expect_field(tagged_type, "ptr_ref_field", ptr_type);
+  }
 }

--- a/tools/fuzzer/symbol_table_test.cc
+++ b/tools/fuzzer/symbol_table_test.cc
@@ -16,8 +16,6 @@
 
 #include "tools/fuzzer/symbol_table.h"
 
-#include <algorithm>
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "lldb-eval/runner.h"


### PR DESCRIPTION
Note: it also imports fields of platform internal structs, e.g. `struct _Mbstatet`, `struct _ldiv_t` on Windows.