### PR TITLE
Fix lookup for global pointer and reference identifiers

### DIFF
--- a/lldb-eval/context.cc
+++ b/lldb-eval/context.cc
@@ -183,7 +183,9 @@ lldb::SBValue Context::LookupIdentifier(const std::string& name) const {
 
       if (val_name == name_ref ||
           val_name == llvm::formatv("::{0}", name_ref).str() ||
-          val_name.endswith(llvm::formatv(" {0}", name_ref).str())) {
+          val_name.endswith(llvm::formatv(" {0}", name_ref).str()) ||
+          val_name.endswith(llvm::formatv("*{0}", name_ref).str()) ||
+          val_name.endswith(llvm::formatv("&{0}", name_ref).str())) {
         value = val;
         break;
       }

--- a/lldb-eval/eval_test.cc
+++ b/lldb-eval/eval_test.cc
@@ -822,6 +822,23 @@ TEST_F(EvalTest, TestMemberOfInheritance) {
   EXPECT_THAT(Eval("parent->z"), IsEqual("3"));
 }
 
+TEST_F(EvalTest, TestGlobalVariableLookup) {
+  EXPECT_THAT(Eval("globalVar"), IsEqual("-559038737"));  // 0xDEADBEEF
+  EXPECT_THAT(Eval("globalPtr"), IsOk());
+  EXPECT_THAT(Eval("globalRef"), IsEqual("-559038737"));
+  EXPECT_THAT(Eval("::globalPtr"), IsOk());
+  EXPECT_THAT(Eval("::globalRef"), IsEqual("-559038737"));
+
+  EXPECT_THAT(Eval("externGlobalVar"), IsEqual("12648430"));  // 0x00CC0FFEE
+  EXPECT_THAT(Eval("::externGlobalVar"), IsEqual("12648430"));
+
+  EXPECT_THAT(Eval("ns::globalVar"), IsEqual("13"));
+  EXPECT_THAT(Eval("ns::globalPtr"), IsOk());
+  EXPECT_THAT(Eval("ns::globalRef"), IsEqual("13"));
+  EXPECT_THAT(Eval("::ns::globalVar"), IsEqual("13"));
+  EXPECT_THAT(Eval("::ns::globalPtr"), IsOk());
+}
+
 TEST_F(EvalTest, TestInstanceVariables) {
   EXPECT_THAT(Eval("this->field_"), IsEqual("1"));
   EXPECT_THAT(Eval("this.field_"),

--- a/lldb-eval/eval_test.cc
+++ b/lldb-eval/eval_test.cc
@@ -829,7 +829,7 @@ TEST_F(EvalTest, TestGlobalVariableLookup) {
   EXPECT_THAT(Eval("::globalPtr"), IsOk());
   EXPECT_THAT(Eval("::globalRef"), IsEqual("-559038737"));
 
-  EXPECT_THAT(Eval("externGlobalVar"), IsEqual("12648430"));  // 0x00CC0FFEE
+  EXPECT_THAT(Eval("externGlobalVar"), IsEqual("12648430"));  // 0x00C0FFEE
   EXPECT_THAT(Eval("::externGlobalVar"), IsEqual("12648430"));
 
   EXPECT_THAT(Eval("ns::globalVar"), IsEqual("13"));

--- a/testdata/test_binary.cc
+++ b/testdata/test_binary.cc
@@ -235,6 +235,19 @@ class C {
 int globalVar = 0xDEADBEEF;
 extern int externGlobalVar;
 
+int* globalPtr = &globalVar;
+int& globalRef = globalVar;
+
+namespace ns {
+int globalVar = 13;
+int* globalPtr = &globalVar;
+int& globalRef = globalVar;
+}  // namespace ns
+
+void TestGlobalVariableLookup() {
+  // BREAK(TestGlobalVariableLookup)
+}
+
 class TestMethods {
  public:
   void TestInstanceVariables() {
@@ -728,6 +741,7 @@ void main() {
   TestLocalVariables();
   TestMemberOf();
   TestMemberOfInheritance();
+  TestGlobalVariableLookup();
   tm.TestInstanceVariables();
   TestIndirection();
   tm.TestAddressOf(42);


### PR DESCRIPTION
LLDB API's `SBValue::GetName()` sometimes include a variable's type, which makes identifier lookup a bit trickier. `lldb-eval` already tries to match name by ignoring everything in front of the last occurrence of space (e.g. for names in the form of `"const int var"`), but that isn't sufficient for pointer and reference types where `*` and `&` symbols are adjacent to the name (e.g. `"int *ptr"`, `"int &ref"`). This change solves this by adding checks to ignore everything in front of the last occurrence of `*` or `&`.