### PR TITLE
Fixes required for targeting wasm32

### DIFF
--- a/lldb-eval/eval.cc
+++ b/lldb-eval/eval.cc
@@ -984,8 +984,9 @@ Value Interpreter::EvaluateComparison(BinaryOpKind kind, Value lhs, Value rhs) {
   // Must be pointer/integer and/or nullptr comparison.
   size_t ptr_size = target_.GetAddressByteSize() * 8;
 
-  bool ret = Compare(kind, llvm::APSInt(lhs.GetInteger().trunc(ptr_size), true),
-                     llvm::APSInt(rhs.GetInteger().trunc(ptr_size), true));
+  bool ret =
+      Compare(kind, llvm::APSInt(lhs.GetInteger().sextOrTrunc(ptr_size), true),
+              llvm::APSInt(rhs.GetInteger().sextOrTrunc(ptr_size), true));
   return CreateValueFromBool(target_, ret);
 }
 

--- a/lldb-eval/eval.cc
+++ b/lldb-eval/eval.cc
@@ -982,7 +982,7 @@ Value Interpreter::EvaluateComparison(BinaryOpKind kind, Value lhs, Value rhs) {
   }
 
   // Must be pointer/integer and/or nullptr comparison.
-  size_t ptr_size = target_.GetAddressByteSize();
+  size_t ptr_size = target_.GetAddressByteSize() * 8;
 
   bool ret = Compare(kind, llvm::APSInt(lhs.GetInteger().trunc(ptr_size), true),
                      llvm::APSInt(rhs.GetInteger().trunc(ptr_size), true));

--- a/lldb-eval/eval.cc
+++ b/lldb-eval/eval.cc
@@ -981,6 +981,11 @@ Value Interpreter::EvaluateComparison(BinaryOpKind kind, Value lhs, Value rhs) {
   }
 
   // Must be pointer/integer and/or nullptr comparison.
+  if (target_.GetAddressByteSize() == 4) {
+    bool ret = Compare(kind, static_cast<uint32_t>(lhs.GetUInt64()),
+                       static_cast<uint32_t>(rhs.GetUInt64()));
+    return CreateValueFromBool(target_, ret);
+  }
   bool ret = Compare(kind, lhs.GetUInt64(), rhs.GetUInt64());
   return CreateValueFromBool(target_, ret);
 }

--- a/lldb-eval/eval.cc
+++ b/lldb-eval/eval.cc
@@ -981,12 +981,10 @@ Value Interpreter::EvaluateComparison(BinaryOpKind kind, Value lhs, Value rhs) {
   }
 
   // Must be pointer/integer and/or nullptr comparison.
-  if (target_.GetAddressByteSize() == 4) {
-    bool ret = Compare(kind, static_cast<uint32_t>(lhs.GetUInt64()),
-                       static_cast<uint32_t>(rhs.GetUInt64()));
-    return CreateValueFromBool(target_, ret);
-  }
-  bool ret = Compare(kind, lhs.GetUInt64(), rhs.GetUInt64());
+  size_t ptr_size = target_.GetAddressByteSize();
+
+  bool ret = Compare(kind, lhs.GetInteger().trunc(ptr_size),
+                     rhs.GetInteger().trunc(ptr_size));
   return CreateValueFromBool(target_, ret);
 }
 

--- a/lldb-eval/eval.cc
+++ b/lldb-eval/eval.cc
@@ -24,6 +24,7 @@
 #include "lldb/API/SBType.h"
 #include "lldb/API/SBValue.h"
 #include "lldb/lldb-enumerations.h"
+#include "llvm/ADT/APSInt.h"
 #include "llvm/Support/FormatVariadic.h"
 
 namespace lldb_eval {
@@ -983,8 +984,8 @@ Value Interpreter::EvaluateComparison(BinaryOpKind kind, Value lhs, Value rhs) {
   // Must be pointer/integer and/or nullptr comparison.
   size_t ptr_size = target_.GetAddressByteSize();
 
-  bool ret = Compare(kind, lhs.GetInteger().trunc(ptr_size),
-                     rhs.GetInteger().trunc(ptr_size));
+  bool ret = Compare(kind, llvm::APSInt(lhs.GetInteger().trunc(ptr_size), true),
+                     llvm::APSInt(rhs.GetInteger().trunc(ptr_size), true));
   return CreateValueFromBool(target_, ret);
 }
 

--- a/lldb-eval/eval_test.cc
+++ b/lldb-eval/eval_test.cc
@@ -726,7 +726,11 @@ TEST_F(EvalTest, TestPointerArithmetic) {
   EXPECT_THAT(Eval("array_ref - 1"), IsOk());
   EXPECT_THAT(
       Eval("1 - array"),
+#ifndef __EMSCRIPTEN__
+      IsError("invalid operands to binary expression ('int' and 'int [10]')\n"
+#else
       IsError("invalid operands to binary expression ('int' and 'int[10]')\n"
+#endif
               "1 - array\n"
               "  ^"));
 
@@ -736,7 +740,11 @@ TEST_F(EvalTest, TestPointerArithmetic) {
   EXPECT_THAT(
       Eval("array + array"),
       IsError(
+#ifndef __EMSCRIPTEN__
+          "invalid operands to binary expression ('int [10]' and 'int [10]')\n"
+#else
           "invalid operands to binary expression ('int[10]' and 'int[10]')\n"
+#endif
           "array + array\n"
           "      ^"));
 }
@@ -799,29 +807,66 @@ TEST_F(EvalTest, PointerIntegerComparison) {
   EXPECT_THAT(Eval("0 == std_nullptr_t"), IsEqual("true"));
   EXPECT_THAT(Eval("std_nullptr_t != 0"), IsEqual("false"));
 
-  EXPECT_THAT(Eval("(void*)0 > nullptr"),
-              IsError("invalid operands to binary expression ('void *' and "
-                      "'std::nullptr_t')"));
+  EXPECT_THAT(
+      Eval("(void*)0 > nullptr"),
+      IsError(
+#ifndef __EMSCRIPTEN__
+          "invalid operands to binary expression ('void *' and 'nullptr_t')"
+#else
+          "invalid operands to binary expression ('void *' and "
+          "'std::nullptr_t')"
+#endif
+          ));
 
-  EXPECT_THAT(Eval("nullptr > 0"),
-              IsError("invalid operands to binary expression ('std::nullptr_t' "
-                      "and 'int')"));
+  EXPECT_THAT(
+      Eval("nullptr > 0"),
+      IsError(
+#ifndef __EMSCRIPTEN__
+          "invalid operands to binary expression ('nullptr_t' and 'int')"
+#else
+          "invalid operands to binary expression ('std::nullptr_t' and 'int')"
+#endif
+          ));
 
-  EXPECT_THAT(Eval("1 == nullptr"),
-              IsError("invalid operands to binary expression ('int' and "
-                      "'std::nullptr_t')"));
+  EXPECT_THAT(
+      Eval("1 == nullptr"),
+      IsError(
+#ifndef __EMSCRIPTEN__
+          "invalid operands to binary expression ('int' and 'nullptr_t')"
+#else
+          "invalid operands to binary expression ('int' and 'std::nullptr_t')"
+#endif
+          ));
 
-  EXPECT_THAT(Eval("nullptr == (int)0"),
-              IsError("invalid operands to binary expression ('std::nullptr_t' "
-                      "and 'int')"));
+  EXPECT_THAT(
+      Eval("nullptr == (int)0"),
+      IsError(
+#ifndef __EMSCRIPTEN__
+          "invalid operands to binary expression ('nullptr_t' and 'int')"
+#else
+          "invalid operands to binary expression ('std::nullptr_t' and 'int')"
+#endif
+          ));
 
-  EXPECT_THAT(Eval("false == nullptr"),
-              IsError("invalid operands to binary expression ('bool' and "
-                      "'std::nullptr_t')"));
+  EXPECT_THAT(
+      Eval("false == nullptr"),
+      IsError(
+#ifndef __EMSCRIPTEN__
+          "invalid operands to binary expression ('bool' and 'nullptr_t')"
+#else
+          "invalid operands to binary expression ('bool' and 'std::nullptr_t')"
+#endif
+          ));
 
-  EXPECT_THAT(Eval("nullptr == (true ? 0 : 0)"),
-              IsError("invalid operands to binary expression ('std::nullptr_t' "
-                      "and 'int')"));
+  EXPECT_THAT(
+      Eval("nullptr == (true ? 0 : 0)"),
+      IsError(
+#ifndef __EMSCRIPTEN__
+          "invalid operands to binary expression ('nullptr_t' and 'int')"
+#else
+          "invalid operands to binary expression ('std::nullptr_t' and 'int')"
+#endif
+          ));
 
   // TODO: Enable when we support char literals.
   // EXPECT_THAT(
@@ -829,10 +874,16 @@ TEST_F(EvalTest, PointerIntegerComparison) {
   //     IsError(
   //         "invalid operands to binary expression ('char' and 'nullptr_t')"));
 
-  EXPECT_THAT(
-      Eval("nullptr > nullptr"),
-      IsError("invalid operands to binary expression ('std::nullptr_t' and "
-              "'std::nullptr_t')"));
+  EXPECT_THAT(Eval("nullptr > nullptr"),
+              IsError(
+#ifndef __EMSCRIPTEN__
+                  "invalid operands to binary expression ('nullptr_t' and "
+                  "'nullptr_t')"
+#else
+                  "invalid operands to binary expression ('std::nullptr_t' and "
+                  "'std::nullptr_t')"
+#endif
+                  ));
 
   // These are not allowed by C++, but we support it as an extension.
   EXPECT_THAT(Eval("(void*)1 == 1"), IsEqual("true"));
@@ -993,7 +1044,12 @@ TEST_F(EvalTest, TestMemberOf) {
   EXPECT_THAT(
       Eval("sarr.x"),
       IsError(
-          "member reference base type 'Sx[2]' is not a structure or union"));
+#ifndef __EMSCRIPTEN__
+          "member reference base type 'Sx [2]' is not a structure or union"
+#else
+          "member reference base type 'Sx[2]' is not a structure or union"
+#endif
+          ));
 
   // Test for record typedefs.
   EXPECT_THAT(Eval("sa.x"), IsEqual("3"));
@@ -1196,7 +1252,7 @@ TEST_F(EvalTest, TestSubscript) {
 
   // Test when base and index are typedefs.
   bool compare_types = true;
-#if LLVM_VERSION_MAJOR < 12
+#ifndef __EMSCRIPTEN__
   // Older LLVM versions return canonical types when accessing array elements.
   compare_types = false;
 #endif
@@ -1414,12 +1470,25 @@ TEST_F(EvalTest, TestCStyleCastPointer) {
   EXPECT_THAT(Eval("(std::nullptr_t)0"),
               IsEqual(Is32Bit() ? "0x00000000" : "0x0000000000000000"));
 
-  EXPECT_THAT(
-      Eval("(std::nullptr_t)1"),
-      IsError("C-style cast from 'int' to 'std::nullptr_t' is not allowed"));
-  EXPECT_THAT(
-      Eval("(std::nullptr_t)ap"),
-      IsError("C-style cast from 'int *' to 'std::nullptr_t' is not allowed"));
+  EXPECT_THAT(Eval("(std::nullptr_t)1"),
+              IsError(
+#ifndef __EMSCRIPTEN__
+                  "C-style cast from 'int' to 'std::nullptr_t' (aka "
+                  "'nullptr_t') is not allowed"
+#else
+
+                  "C-style cast from 'int' to 'std::nullptr_t' is not allowed"
+#endif
+                  ));
+  EXPECT_THAT(Eval("(std::nullptr_t)ap"),
+              IsError(
+#ifndef __EMSCRIPTEN__
+                  "C-style cast from 'int *' to 'std::nullptr_t' (aka "
+                  "'nullptr_t') is not allowed"
+#else
+                  "C-style cast from 'int *' to 'std::nullptr_t' is not allowed"
+#endif
+                  ));
 }
 
 TEST_F(EvalTest, TestCStyleCastNullptrType) {
@@ -1491,10 +1560,15 @@ TEST_F(EvalTest, TestCxxStaticCast) {
   EXPECT_THAT(Eval("static_cast<td_int_t>(4)"), IsEqual("4"));
   EXPECT_THAT(Eval("static_cast<int>(td_int)"), IsEqual("13"));
 
-  EXPECT_THAT(
-      Eval("static_cast<long long>(nullptr)"),
-      IsError(
-          "static_cast from 'std::nullptr_t' to 'long long' is not allowed"));
+  EXPECT_THAT(Eval("static_cast<long long>(nullptr)"),
+              IsError(
+#ifndef __EMSCRIPTEN__
+                  "static_cast from 'nullptr_t' to 'long long' is not allowed"
+#else
+                  "static_cast from 'std::nullptr_t' to 'long long' is not "
+                  "allowed"
+#endif
+                  ));
   EXPECT_THAT(
       Eval("static_cast<long long>(ptr)"),
       IsError("static_cast from 'int *' to 'long long' is not allowed"));
@@ -1520,7 +1594,11 @@ TEST_F(EvalTest, TestCxxStaticCast) {
 
   EXPECT_THAT(
       Eval("static_cast<UEnum>(nullptr)"),
+#ifndef __EMSCRIPTEN__
+      IsError("static_cast from 'nullptr_t' to 'UEnum' is not allowed"));
+#else
       IsError("static_cast from 'std::nullptr_t' to 'UEnum' is not allowed"));
+#endif
   EXPECT_THAT(Eval("static_cast<UEnum>(ptr)"),
               IsError("static_cast from 'int *' to 'UEnum' is not allowed"));
   EXPECT_THAT(
@@ -1547,12 +1625,24 @@ TEST_F(EvalTest, TestCxxStaticCast) {
               IsEqual(Is32Bit() ? "0x00000000" : "0x0000000000000000"));
   EXPECT_THAT(Eval("static_cast<std::nullptr_t>(0)"),
               IsEqual(Is32Bit() ? "0x00000000" : "0x0000000000000000"));
-  EXPECT_THAT(
-      Eval("static_cast<std::nullptr_t>((int)0)"),
-      IsError("static_cast from 'int' to 'std::nullptr_t' is not allowed"));
-  EXPECT_THAT(
-      Eval("static_cast<std::nullptr_t>((void*)0)"),
-      IsError("static_cast from 'void *' to 'std::nullptr_t' is not allowed"));
+  EXPECT_THAT(Eval("static_cast<std::nullptr_t>((int)0)"),
+              IsError(
+#ifndef __EMSCRIPTEN__
+                  "static_cast from 'int' to 'std::nullptr_t' (aka "
+                  "'nullptr_t') is not allowed"
+#else
+                  "static_cast from 'int' to 'std::nullptr_t' is not allowed"
+#endif
+                  ));
+  EXPECT_THAT(Eval("static_cast<std::nullptr_t>((void*)0)"),
+              IsError(
+#ifndef __EMSCRIPTEN__
+                  "static_cast from 'void *' to 'std::nullptr_t' (aka "
+                  "'nullptr_t') is not allowed"
+#else
+                  "static_cast from 'void *' to 'std::nullptr_t' is not allowed"
+#endif
+                  ));
 
   // Cast to references.
   EXPECT_THAT(Eval("static_cast<int&>(parent.b)"), IsEqual("2"));
@@ -1739,22 +1829,48 @@ TEST_F(EvalTest, TestCxxReinterpretCast) {
   EXPECT_THAT(Eval("*reinterpret_cast<long long*>(arr)"),
               IsEqual("8589934593"));  // 8589934593 == 0x0000000200000001
 
-  // Casting to nullptr_t or nullptr_t to pointer types isn't
-  // allowed.
+  // Casting to nullptr_t or nullptr_t to pointer types isn't allowed.
   EXPECT_THAT(Eval("reinterpret_cast<void*>(nullptr)"),
-              IsError("reinterpret_cast from 'std::nullptr_t' to 'void "
-                      "*' is not allowed"));
-  EXPECT_THAT(
-      Eval("reinterpret_cast<std::nullptr_t>(ptr)"),
-      IsError(
-          "reinterpret_cast from 'int *' to 'std::nullptr_t' is not allowed"));
-  EXPECT_THAT(
-      Eval("reinterpret_cast<std::nullptr_t>(0)"),
-      IsError(
-          "reinterpret_cast from 'int' to 'std::nullptr_t' is not allowed"));
+              IsError(
+#ifndef __EMSCRIPTEN__
+                  "reinterpret_cast from 'nullptr_t' to 'void *' is not allowed"
+#else
+                   "reinterpret_cast from 'std::nullptr_t' to 'void *' is not "
+                   "allowed"
+#endif
+                  ));
+  EXPECT_THAT(Eval("reinterpret_cast<std::nullptr_t>(ptr)"),
+              IsError(
+#ifndef __EMSCRIPTEN__
+                  "reinterpret_cast from 'int *' to 'std::nullptr_t' (aka "
+                  "'nullptr_t') is not allowed"
+#else
+                  "reinterpret_cast from 'int *' to 'std::nullptr_t' is not "
+                  "allowed"
+#endif
+                  ));
+  EXPECT_THAT(Eval("reinterpret_cast<std::nullptr_t>(0)"),
+              IsError(
+#ifndef __EMSCRIPTEN__
+                  "reinterpret_cast from 'int' to 'std::nullptr_t' (aka "
+                  "'nullptr_t') is not allowed"
+#else
+                  "reinterpret_cast from 'int' to 'std::nullptr_t' is "
+                  "not allowed"
+#endif
+                  ));
   EXPECT_THAT(Eval("reinterpret_cast<std::nullptr_t>(nullptr)"),
-              IsError("reinterpret_cast from 'std::nullptr_t' to 'std::nullptr_t' "
-                      "is not allowed"));
+              IsError(
+#ifndef __EMSCRIPTEN__
+                  "reinterpret_cast from 'nullptr_t' to "
+                  "'std::nullptr_t' "
+                  "(aka 'nullptr_t') is not allowed"
+#else
+                  "reinterpret_cast from 'std::nullptr_t' to "
+                  "'std::nullptr_t' "
+                  "is not allowed"
+#endif
+                  ));
 
   // L-values can be converted to reference type.
   EXPECT_THAT(Eval("reinterpret_cast<CxxBase&>(arr[0]).a"), IsEqual("1"));
@@ -1764,9 +1880,9 @@ TEST_F(EvalTest, TestCxxReinterpretCast) {
   EXPECT_THAT(Eval("reinterpret_cast<CxxParent&>(arr).d"), IsEqual("5"));
   EXPECT_THAT(Eval("reinterpret_cast<int&>(parent)"), IsOk());
   EXPECT_THAT(Eval("reinterpret_cast<td_int_ref_t>(ptr)"), IsOk());
-  EXPECT_THAT(Eval("reinterpret_cast<int&>(5)"),
-              IsError("reinterpret_cast from rvalue to reference "
-                      "type 'int &'"));
+  EXPECT_THAT(
+      Eval("reinterpret_cast<int&>(5)"),
+      IsError("reinterpret_cast from rvalue to reference type 'int &'"));
 
   // Is result L-value or R-value?
   EXPECT_THAT(Eval("&reinterpret_cast<int&>(arr[0])"), IsOk());
@@ -1818,7 +1934,7 @@ TEST_F(EvalTest, DISABLED_TestStaticConstDeclaredInline) {
 }
 
 TEST_F(EvalTest, TestStaticConstDeclaredOutsideTheClass) {
-#if LLVM_VERSION_MAJOR < 12
+#ifndef __EMSCRIPTEN__
   // Upstream LLDB doesn't handle static const variables.
   this->compare_with_lldb_ = false;
 #endif

--- a/lldb-eval/eval_test.cc
+++ b/lldb-eval/eval_test.cc
@@ -586,7 +586,7 @@ TEST_F(EvalTest, TestArithmetic) {
   EXPECT_THAT(Eval("(r < r > r)"), IsEqual("false"));
 
   // On Windows sizeof(int) == sizeof(long) == 4.
-  if (sizeof(int) == sizeof(long)) {
+  if constexpr (sizeof(int) == sizeof(long)) {
     EXPECT_THAT(Eval("(unsigned int)4294967295 + (long)2"), IsEqual("1"));
     EXPECT_THAT(Eval("((unsigned int)1 + (long)1) - 3"), IsEqual("4294967295"));
   } else {
@@ -1976,7 +1976,7 @@ TEST_F(EvalTest, TestBasicTypeDeclaration) {
   EXPECT_THAT(Eval("(char unsigned)65"), IsEqual("'A'"));
   EXPECT_THAT(Eval("(signed char)65"), IsEqual("'A'"));
 #ifndef __EMSCRIPTEN__
-  if (sizeof(wchar_t) == 2) {
+  if constexpr (sizeof(wchar_t) == 2) {
     // Size of "wchar_t" is 2 bytes on Windows.
     EXPECT_THAT(Eval("(wchar_t)0x4141"), IsEqual("AA"));
   } else {
@@ -2000,7 +2000,7 @@ TEST_F(EvalTest, TestBasicTypeDeclaration) {
   EXPECT_THAT(Eval("(long)-1"), IsEqual("-1"));
   EXPECT_THAT(Eval("(signed long)-1"), IsEqual("-1"));
   EXPECT_THAT(Eval("(long int signed)-1"), IsEqual("-1"));
-  if (sizeof(long) == 4) {
+  if constexpr (sizeof(long) == 4) {
     // Size of "long" is 4 bytes on Windows.
     EXPECT_THAT(Eval("(unsigned long)-1"), IsEqual("4294967295"));
     EXPECT_THAT(Eval("(int long unsigned)-1"), IsEqual("4294967295"));

--- a/lldb-eval/eval_test.cc
+++ b/lldb-eval/eval_test.cc
@@ -1975,6 +1975,7 @@ TEST_F(EvalTest, TestBasicTypeDeclaration) {
   EXPECT_THAT(Eval("(char)65"), IsEqual("'A'"));
   EXPECT_THAT(Eval("(char unsigned)65"), IsEqual("'A'"));
   EXPECT_THAT(Eval("(signed char)65"), IsEqual("'A'"));
+#ifndef __EMSCRIPTEN__
   if (sizeof(wchar_t) == 2) {
     // Size of "wchar_t" is 2 bytes on Windows.
     EXPECT_THAT(Eval("(wchar_t)0x4141"), IsEqual("AA"));
@@ -1984,6 +1985,7 @@ TEST_F(EvalTest, TestBasicTypeDeclaration) {
   }
   EXPECT_THAT(Eval("(char16_t)0x4141"), IsEqual("U+4141"));
   EXPECT_THAT(Eval("(char32_t)0x4141"), IsEqual("U+0x00004141"));
+#endif
   EXPECT_THAT(Eval("(int short)-1"), IsEqual("-1"));
   EXPECT_THAT(Eval("(short int)-1"), IsEqual("-1"));
   EXPECT_THAT(Eval("(short)-1"), IsEqual("-1"));

--- a/lldb-eval/value.cc
+++ b/lldb-eval/value.cc
@@ -15,6 +15,7 @@
 #include "lldb-eval/value.h"
 
 #include <cmath>
+
 #include "lldb-eval/context.h"
 #include "lldb-eval/defines.h"
 #include "lldb-eval/traits.h"

--- a/lldb-eval/value.cc
+++ b/lldb-eval/value.cc
@@ -14,6 +14,7 @@
 
 #include "lldb-eval/value.h"
 
+#include <cmath>
 #include "lldb-eval/context.h"
 #include "lldb-eval/defines.h"
 #include "lldb-eval/traits.h"


### PR DESCRIPTION
Drive-by: Fix pointer comparison on 32bit targets